### PR TITLE
Fix logs cut when they are too big

### DIFF
--- a/flutter_fimber/lib/flutter_fimber.dart
+++ b/flutter_fimber/lib/flutter_fimber.dart
@@ -142,11 +142,17 @@ class LogLine {
 /// which is not skipping log lines printed on Android
 /// https://flutter.io/docs/testing/debugging#print-and-debugprint-with-flutter-logs
 class DebugBufferTree extends DebugTree {
+  /// Max limit that a log can reach to start dividing it into multiple chunks
+  /// avoiding them to be cut by android log
+  /// - when -1 will disable chunking of the logs
+  final int maxLineSize;
+
   /// Creates Debug Tree compatible with Android.
-  DebugBufferTree(
-      {int printTimeType = DebugTree.timeClockType,
-      List<String> logLevels = DebugTree.defaultLevels})
-      : super(printTimeType: printTimeType, logLevels: logLevels);
+  DebugBufferTree({
+    int printTimeType = DebugTree.timeClockType,
+    List<String> logLevels = DebugTree.defaultLevels,
+    this.maxLineSize = 800,
+  }) : super(printTimeType: printTimeType, logLevels: logLevels);
 
   /// Creates elapsed time Debug Tree compatible with Android.
   factory DebugBufferTree.elapsed(
@@ -159,7 +165,14 @@ class DebugBufferTree extends DebugTree {
   /// src: https://github.com/flutter/flutter/issues/22665#issuecomment-458186456
   @override
   void printLog(String logLine, {String level}) {
-    final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
-    pattern.allMatches(logLine).forEach((match) => debugPrint(match.group(0)));
+    if (maxLineSize == -1) {
+      debugPrint(logLine);
+    } else {
+      final pattern = RegExp('.{1,$maxLineSize}');
+
+      pattern
+          .allMatches(logLine)
+          .forEach((match) => debugPrint(match.group(0)));
+    }
   }
 }

--- a/flutter_fimber/lib/flutter_fimber.dart
+++ b/flutter_fimber/lib/flutter_fimber.dart
@@ -155,9 +155,11 @@ class DebugBufferTree extends DebugTree {
         logLevels: logLevels, printTimeType: DebugTree.timeElapsedType);
   }
 
-  /// prints log line with `debugPrint`.
+  /// prints log lines breaking them into multiple lines if its too long.
+  /// src: https://github.com/flutter/flutter/issues/22665#issuecomment-458186456
   @override
   void printLog(String logLine, {String level}) {
-    debugPrint(logLine);
+    final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
+    pattern.allMatches(logLine).forEach((match) => debugPrint(match.group(0)));
   }
 }


### PR DESCRIPTION
Adding this line will cause the logs to be cut into multiple lines.

Im not sure if this is the best way, Im also not sure how to add unit tests for this, any hint?

Fixes https://github.com/magillus/flutter-fimber/issues/89.

The fix idea comes from here https://github.com/flutter/flutter/issues/22665